### PR TITLE
Fixed space usage in stat(2) calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ happen when copying non-segmented large files server-side. Default is 5 minutes.
 
 #### Prefetch options
 
+* `block_size`: Filesystem block size in bytes. This is only used to report correct `stat()` results.
 * `readahead_size`: Readahead size in KB. Default is 128 KB.
 * `readdir`: Overall concurrency factor when listing segmented objects in directories (default is 20).
 * `extra_attr`: Fetch extended attributes (default is false). Required with security options.

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func parseFlags(debug *bool, profAddr, cpuProf, memProf *string) {
 	// Prefetch
 	flag.Uint64Var(&svfs.ListerConcurrency, "readdir-concurrency", 20, "Directory listing concurrency")
 	flag.BoolVar(&svfs.ExtraAttr, "readdir-extra-attributes", false, "Fetch extra attributes")
+	flag.UintVar(&svfs.BlockSize, "block-size", 4096, "Block size in bytes")
 	flag.UintVar(&svfs.ReadAheadSize, "readahead-size", 128, "Per file readahead size in KiB")
 
 	// Cache Options
@@ -65,7 +66,7 @@ func parseFlags(debug *bool, profAddr, cpuProf, memProf *string) {
 
 	// Encryption
 	flag.StringVar(&svfs.KeyFile, "encryption-key", "", "Path to 16, 24 or 32 bytes AES private key file")
-	flag.Int64Var(&svfs.BlockSize, "encryption-chunk", 512, "Encryption block size in KiB")
+	flag.Int64Var(&svfs.ChunkSize, "encryption-chunk", 512, "Encryption block size in KiB")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage : %s [OPTIONS] DEVICE MOUNTPOINT\n\n", os.Args[0])
@@ -97,7 +98,7 @@ func mountOptions(device string) (options []fuse.MountOption) {
 func checkOptions() (err error) {
 	// Convert units
 	svfs.SegmentSize *= (1 << 20)
-	svfs.BlockSize *= (1 << 10)
+	svfs.ChunkSize *= (1 << 10)
 	svfs.ReadAheadSize *= (1 << 10)
 
 	// Should not exceed swift maximum object size.

--- a/scripts/mount.svfs
+++ b/scripts/mount.svfs
@@ -18,6 +18,7 @@ OPTIONS = {
     'aes_key'           => '--encryption-key',
     'allow_other'       => '--allow-other',
     'allow_root'        => '--allow-root',
+    'block_size'        => '--block-size',
     'cache_access'      => '--cache-max-access',
     'cache_entries'     => '--cache-max-entries',
     'cache_ttl'         => '--cache-ttl',

--- a/svfs/directory.go
+++ b/svfs/directory.go
@@ -45,7 +45,7 @@ func (d *Directory) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Mode = os.ModeDir | os.FileMode(DefaultMode)
 	a.Gid = uint32(DefaultGID)
 	a.Uid = uint32(DefaultUID)
-	a.Size = uint64(4096)
+	a.Size = uint64(BlockSize)
 
 	if d.so != nil {
 		a.Mtime = getMtime(d.so, d.sh)

--- a/svfs/fs.go
+++ b/svfs/fs.go
@@ -21,6 +21,7 @@ var (
 	DefaultUID         uint64
 	DefaultMode        uint64
 	DefaultPermissions bool
+	BlockSize          uint
 	ReadAheadSize      uint
 
 	// Encryption
@@ -28,7 +29,7 @@ var (
 	Encryption bool
 	KeyFile    string
 	Key        []byte
-	BlockSize  int64
+	ChunkSize  int64
 )
 
 // SVFS implements the Swift Virtual File System.

--- a/svfs/object.go
+++ b/svfs/object.go
@@ -37,6 +37,8 @@ type Object struct {
 // Attr fills the file attributes for an object node.
 func (o *Object) Attr(ctx context.Context, a *fuse.Attr) (err error) {
 	a.Size = o.size()
+	a.BlockSize = uint32(BlockSize)
+	a.Blocks = (a.Size / uint64(a.BlockSize)) * 8
 	a.Mode = os.FileMode(DefaultMode)
 	a.Gid = uint32(DefaultGID)
 	a.Uid = uint32(DefaultUID)

--- a/svfs/swift.go
+++ b/svfs/swift.go
@@ -19,7 +19,7 @@ func newReader(fh *ObjectHandle) (io.ReadSeeker, error) {
 	}
 
 	if Encryption && headers[ObjectNonceHeader] != "" {
-		crd := NewCryptoReadSeeker(rd, BlockSize, int64(Cipher.Overhead()))
+		crd := NewCryptoReadSeeker(rd, ChunkSize, int64(Cipher.Overhead()))
 		nonce, err := hex.DecodeString(headers[ObjectNonceHeader])
 		if err != nil {
 			return nil, fmt.Errorf("Failed to decode nonce")
@@ -61,7 +61,7 @@ func newWriter(container, path string, iv *string) (io.WriteCloser, error) {
 	}
 
 	if Encryption {
-		cwd := NewCryptoWriter(wd, BlockSize, int64(Cipher.Overhead()))
+		cwd := NewCryptoWriter(wd, ChunkSize, int64(Cipher.Overhead()))
 		cwd.SetCipher(Cipher, nonce)
 		if *iv == "" {
 			*iv = hex.EncodeToString(cwd.Nonce)


### PR DESCRIPTION
This PR fixes block size and block count report in `stat(2)` calls which were set to 0 until now.
This, for instance, permits using `du` over a svfs mountpoint and report the actual used space.