### PR TITLE
Introduce --os-internal-endpoint flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ hubic_token: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX...
 * `region`: the region where your tenant is.
 * `version`: authentication version (`0` means auto-discovery which is the default).
 * `storage_url`: the storage endpoint holding your data.
+* `internal_endpoint`: the storage endpoint type (default is `false`).
 * `token`: a valid token.
 
 Options `region`, `version`, `storage_url` and `token` are guessed during authentication if

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -161,6 +161,7 @@ func setFlags() {
 	flags.StringVar(&svfs.SwiftConnection.ApiKey, "os-password", "", "User password")
 	flags.StringVar(&svfs.SwiftConnection.Region, "os-region-name", "", "Region name")
 	flags.StringVar(&svfs.SwiftConnection.StorageUrl, "os-storage-url", "", "Storage URL")
+	flags.BoolVar(&svfs.SwiftConnection.Internal, "os-internal-endpoint", false, "Use internal storage URL")
 	flags.StringVar(&svfs.SwiftConnection.Tenant, "os-tenant-name", "", "Tenant name")
 	flags.IntVar(&svfs.SwiftConnection.AuthVersion, "os-auth-version", 0, "Authentification version, 0 = auto")
 	flags.DurationVar(&svfs.SwiftConnection.ConnectTimeout, "os-connect-timeout", 15*time.Second, "Swift connection timeout")

--- a/scripts/mount.svfs
+++ b/scripts/mount.svfs
@@ -44,6 +44,7 @@ OPTIONS = {
     'segment_size'      => '--os-segment-size',
     'storage_policy'    => '--os-storage-policy',
     'storage_url'       => '--os-storage-url',
+    'internal_endpoint' => '--os-internal-endpoint',
     'tenant'            => '--os-tenant-name',
     'token'             => '--os-auth-token',
     'transfer_mode'     => '--transfer-mode',


### PR DESCRIPTION
### What I did

Introduced --os-internal-endpoint flag handler

### How I did it

Carefully

### How to verify it

Mount swift storage with the `internal_endpoint` flag

### Description for changelog

Introduced --os-internal-endpoint flag handler. Suitable for private insecure endpoints.

Resolves #142